### PR TITLE
Added architecture check for special Pi handling

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,19 @@
 - name: "include_role geerlingguy.docker"
   ansible.builtin.include_role:
     name: geerlingguy.docker
+  when: ansible_architecture != 'armv7l'
   vars:
     docker_edition: 'ce'
+    docker_users: []
+  tags:
+    - docker
+    - geerlingguy_docker
+
+- name: "include_role geerlingguy.docker_arm"
+  ansible.builtin.include_role:
+    name: geerlingguy.docker_arm
+  when: ansible_architecture == 'armv7l'
+  vars:
     docker_users: []
   tags:
     - docker


### PR DESCRIPTION
geerlingguy has a different role for Raspberry Pi docker-setup. Switching both roles by architecture check. Only armv7l supported.